### PR TITLE
[#15] Enhance todo title handling

### DIFF
--- a/e2e/add-todo.spec.ts
+++ b/e2e/add-todo.spec.ts
@@ -1,26 +1,26 @@
 import test, { expect, Page } from "@playwright/test"
 import { TodoPage } from "./pages/todo.page"
+import { i18n } from "./utils/i18n";
 
 test.describe('It should add a new todo', () => {
   test.describe.configure({ mode: 'serial' })
   
   let page: Page;
   let todoPage: TodoPage;
-
-  
+ 
   test.beforeAll(async ({ browser }) => {
     await TodoPage.resetDB();
 
     page = await browser.newPage()
     todoPage = new TodoPage(page);
     await todoPage.goto();
-  })
+  });
 
   test.afterAll(async () => {
     await TodoPage.resetDB();
 
     await page.close();
-  })
+  });
 
   test('It should add a todo when pressing Enter', async () => {
     const title = 'My first todo';
@@ -30,8 +30,9 @@ test.describe('It should add a new todo', () => {
     await todoPage.addTodoForm.todoInput.press('Enter');
     
     await expect(todoPage.todoTable.todoRows).toHaveCount(todoCount);
+    await todoPage.assertDefaultTodoState(title);
   });
-  
+
   test('It should add a todo when clicking Add button', async () => {
     const title = 'Second todo';
     const todoCount = 2;
@@ -39,5 +40,55 @@ test.describe('It should add a new todo', () => {
     await todoPage.addTodoForm.todoInput.fill(title);
     await todoPage.addTodoForm.addBtn.click();
     await expect(todoPage.todoTable.todoRows).toHaveCount(todoCount)
-  })
+  });
+
+  test('It should reject todo title containing only whitespace', async () => {
+    const title = '  ';
+    const todoCount = 2;
+
+    await todoPage.addTodoForm.todoInput.fill(title);
+    await todoPage.addTodoForm.addBtn.click();
+    await todoPage.assertNotification(i18n.addTodoForm.input.whitespace.messages.error);
+    await expect(todoPage.todoTable.todoRows).toHaveCount(todoCount);
+  });
+
+  test('It should trim leading and trailing space from todo title before adding', async () => {
+    const title = ' todo containing whitespace ';
+    const trimmedTitle = title.trim();
+    const todoCount = 3;
+
+    await todoPage.addTodoForm.todoInput.fill(title);
+    await todoPage.addTodoForm.addBtn.click();
+    await todoPage.assertNotification(i18n.addTodoForm.button.messages.success);
+    const todoText = todoPage.todoTable.todoText(trimmedTitle);
+    await expect(todoText).toBeVisible();
+    await expect(todoText).toHaveText(trimmedTitle);
+    await expect(todoPage.todoTable.todoRows).toHaveCount(todoCount);
+  });
+ 
+  test('It should truncate todo title longer than 40 characters', async () => {
+    const tooLongTitle = 'This title contains more than 40 characters';
+    const expectedTitle = 'This title contains more than 40 charact';
+
+    await todoPage.addTodoForm.todoInput.fill(tooLongTitle);
+    await todoPage.addTodoForm.addBtn.click();
+
+    await todoPage.assertNotification(i18n.addTodoForm.button.messages.success);
+    const todoText = todoPage.todoTable.todoText(expectedTitle);
+    await expect(todoText).toHaveText(expectedTitle);
+  });
+
+  test('It should accept titles exactly 40 characters long', async () => {
+    const title = 'This todo title contains 40 char no more';
+
+    await todoPage.addTodoForm.todoInput.fill(title);
+    await todoPage.addTodoForm.addBtn.click();
+
+    await todoPage.assertNotification(i18n.addTodoForm.button.messages.success);
+    const todoText = todoPage.todoTable.todoText(title);
+    await expect(todoText).toHaveText(title);
+    const todoTitleLength = (await todoText.innerText()).length;
+    const maxLength = 40;
+    expect(todoTitleLength).toBe(maxLength);
+  });
 })

--- a/e2e/edit-todo-title.spec.ts
+++ b/e2e/edit-todo-title.spec.ts
@@ -4,9 +4,9 @@ import { TodoPage } from "./pages/todo.page";
 test.describe.serial('Edit Todo Title', () => {
   let page: Page;
   let todoPage: TodoPage;
-  let todoTitleWrapper: Locator;
+  let todoTextWrapper: Locator;
   let editInput: Locator;
-  let todoTitle: Locator;
+  let todoText: Locator;
   let editButton: Locator;
 
   const TODO_TITLE = 'todo title';
@@ -20,9 +20,9 @@ test.describe.serial('Edit Todo Title', () => {
     await todoPage.goto();
     await todoPage.addTodo(TODO_TITLE);
 
-    todoTitleWrapper = todoPage.todoTable.todoTitleWrapper(TODO_TITLE);
+    todoTextWrapper = todoPage.todoTable.todoTextWrapper(TODO_TITLE);
     editInput = todoPage.todoTable.editInput;
-    todoTitle = todoPage.todoTable.todoTitle(TODO_TITLE_EDITED);
+    todoText = todoPage.todoTable.todoText(TODO_TITLE_EDITED);
     editButton = todoPage.todoTable.editButton;
   });
 
@@ -32,21 +32,23 @@ test.describe.serial('Edit Todo Title', () => {
 
   test.describe('Closes edit mode without changes', () => {
     test('It should close edit mode when pressing Escape key', async () => {
-      await todoTitleWrapper.dblclick();
-      await expect(editInput).toBeVisible();
+      await todoPage.assertDefaultTodoState(TODO_TITLE);
+      await todoTextWrapper.dblclick();
+      await todoPage.assertTodoTitleInEditingState(TODO_TITLE);
+
       await editInput.press('Escape');
       await expect(editInput).toBeHidden();
     });
 
     test('It should close edit mode when pressing Enter key', async () => {
-      await todoTitleWrapper.dblclick();
+      await todoTextWrapper.dblclick();
       await expect(editInput).toBeVisible();
       await editInput.press('Enter');
       await expect(editInput).toBeHidden();
     });
 
     test('It should close edit mode when input loses focus', async () => {
-      await todoTitleWrapper.dblclick();
+      await todoTextWrapper.dblclick();
       await expect(editInput).toBeVisible();
       await todoPage.blur();
       await expect(editInput).toBeHidden();
@@ -67,7 +69,7 @@ test.describe.serial('Edit Todo Title', () => {
 
     test.beforeEach(async () => {
       await todoPage.addTodo(TODO_TITLE);
-      await todoTitleWrapper.dblclick();
+      await todoTextWrapper.dblclick();
       await editInput.fill(TODO_TITLE_EDITED);
     })
 
@@ -79,20 +81,20 @@ test.describe.serial('Edit Todo Title', () => {
 
     test('It should edit title and press Enter', async () => {
       await editInput.press('Enter');
-      await expect(todoTitle).toBeVisible();
-      await expect(todoTitle).toHaveText(TODO_TITLE_EDITED);
+      await expect(todoText).toBeVisible();
+      await expect(todoText).toHaveText(TODO_TITLE_EDITED);
     });
 
     test('It should edit title and press Escape', async () => {
       await editInput.press('Escape');
-      await expect(todoTitle).toBeVisible();
-      await expect(todoTitle).toHaveText(TODO_TITLE_EDITED);
+      await expect(todoText).toBeVisible();
+      await expect(todoText).toHaveText(TODO_TITLE_EDITED);
     });
 
     test('It should edit title and blur', async () => {
       await todoPage.blur();
-      await expect(todoTitle).toBeVisible();
-      await expect(todoTitle).toHaveText(TODO_TITLE_EDITED);
+      await expect(todoText).toBeVisible();
+      await expect(todoText).toHaveText(TODO_TITLE_EDITED);
     });
   });
   test('It should keep previous title if user save with empty title', async () => {
@@ -100,6 +102,6 @@ test.describe.serial('Edit Todo Title', () => {
     await editButton.click();
     await editInput.clear();
     await editInput.press('Enter');
-    await expect(todoTitle).toHaveText(TODO_TITLE_EDITED);
+    await expect(todoText).toHaveText(TODO_TITLE_EDITED);
   });
 })

--- a/e2e/pages/components/todo-table.component.ts
+++ b/e2e/pages/components/todo-table.component.ts
@@ -23,17 +23,21 @@ export class TodoTableComponent {
     return row.getByTestId('todo-row-checkbox');
   }
 
-  todoTitleWrapper(title: string) {
+  todoTextWrapper(title: string) {
     const row = this.todoRow(title);
     return row.getByTestId('todo-text-wrapper');
   }
 
-  todoTitle(title: string) {
+  todoText(title: string) {
     const row = this.todoRow(title);
     return row.getByTestId('todo-text');
   }
 
+  todoTitle(title: string) {
+    return this.todoRows.getByTestId(`title-${title}`);
+  }
+
   todoRow(title: string) {
-    return this.todoRows.filter({ hasText: title});
+    return this.todoRows.filter({ hasText: title });
   }
 }

--- a/e2e/pages/todo.page.ts
+++ b/e2e/pages/todo.page.ts
@@ -1,4 +1,4 @@
-import { Page, request } from "@playwright/test";
+import { expect, Page, request } from "@playwright/test";
 import { i18n } from "../utils/i18n";
 import { AddFormComponent } from "./components/add-form.component";
 import FooterComponent from "./components/footer.component";
@@ -22,7 +22,7 @@ export class TodoPage {
     await this.addTodoForm.todoInput.fill(title);
     await this.addTodoForm.addBtn.click();
 
-    const notifySuccess = this.toastrContainer.filter({ hasText: i18n.addTodoForm.add.messages.success });
+    const notifySuccess = this.toastrContainer.filter({ hasText: i18n.addTodoForm.button.messages.success });
 
     await notifySuccess.waitFor({ state: 'visible' });
     await notifySuccess.waitFor({ state: 'hidden' });
@@ -60,5 +60,27 @@ export class TodoPage {
       position:
         { x: 0, y: 0 }
     });
+  }
+
+  async assertNotification(message: string) {
+    const notificationLocator = this.toastrContainer.filter({ hasText: message });
+
+    await notificationLocator.waitFor({ state: 'visible' });
+    await notificationLocator.waitFor({ state: 'hidden' });
+  }
+
+  async assertDefaultTodoState(title: string) {
+    const todoTitle = this.todoTable.todoTitle(title);
+    await expect(todoTitle).toHaveAttribute('title', i18n.todoTable.row.title.editing.idle);
+    const checkbox = this.todoTable.completeCheckbox(title);
+    await expect(checkbox).toHaveAttribute('title', i18n.todoTable.row.checkboxLabel.unCompleted.title);
+  }
+
+  async assertTodoTitleInEditingState(title: string) {
+    const todoTitle = this.todoTable.todoTitle(title);
+    await expect(todoTitle).toBeVisible();
+    await expect(todoTitle).toHaveAttribute('title', i18n.todoTable.row.title.editing.active);
+    await expect(this.todoTable.editInput).toBeVisible();
+    await expect(this.todoTable.editInput).toHaveValue(title);
   }
 }

--- a/src/app/components/add-form/add-form.component.html
+++ b/src/app/components/add-form/add-form.component.html
@@ -1,9 +1,18 @@
 <form #todoForm="ngForm" class="add-todo-form" (submit)="onAddTodo($event)">
-  <input #todoInput="ngModel" [(ngModel)]="todoName" type="text" name="todoInput" [placeholder]="'addTodoForm.placeholder' | translate" autocomplete="off" required minlength="1">
+  <input
+  #todoInput="ngModel"
+  [(ngModel)]="todoName"
+  type="text"
+  name="todoInput"
+  [placeholder]="'addTodoForm.placeholder' | translate"
+  autocomplete="off"
+  required
+  minlength="1"
+  maxlength="40">
   <button
     class="btn"
     [disabled]="todoForm.invalid || isProcessing"
     type="submit">
-    {{ 'addTodoForm.add.title' | translate }}
+    {{ 'addTodoForm.button.title' | translate }}
   </button>
 </form>

--- a/src/app/components/add-form/add-form.component.ts
+++ b/src/app/components/add-form/add-form.component.ts
@@ -50,13 +50,22 @@ export class AddFormComponent implements OnInit, OnDestroy {
     e.preventDefault();
     if (this.isProcessing) return;
 
-    const prefix = 'addTodoForm.add';
-    this.todoService.addTodo(this.todoName)
+    const inputPrefix = 'addTodoForm.input';
+    const trimmedName = this.todoName.trim();
+    if(!trimmedName) {
+      this.notificationService.notifyError(`${inputPrefix}.whitespace`)
+      .pipe(takeUntil(this._destroy$))
+      .subscribe();
+      return;
+    }
+
+    const buttonPrefix = 'addTodoForm.button';
+    this.todoService.addTodo(trimmedName)
       .pipe(
-        switchMap(() => this.notificationService.notifySuccess(prefix)),
+        switchMap(() => this.notificationService.notifySuccess(buttonPrefix)),
         switchMap(() => this.todoService.refreshTodos(this.pageInfo.currentPage)),
         tap(() => this.todoName = ''),
-        catchError(() => this.notificationService.notifyError(prefix)),
+        catchError(() => this.notificationService.notifyError(buttonPrefix)),
         finalize(() => this.todoService.setProcessing(false)),
       )
       .subscribe();

--- a/src/app/components/todo-table-row/todo-table-row.component.html
+++ b/src/app/components/todo-table-row/todo-table-row.component.html
@@ -1,6 +1,11 @@
 <td style="width: 6%;">{{ todo.id }}</td>
 <td style="width: 56%;">
-  <div class="title">
+  <div
+    [attr.data-testid]="'title-' + todo.title"
+    [title]="(editing 
+      ? 'todoTable.row.title.editing.active'
+      : 'todoTable.row.title.editing.idle') | translate"
+    class="title">
       <input
       data-testid="todo-row-checkbox"
       [disabled]="isProcessing"
@@ -8,6 +13,9 @@
       [checked]="!!todo.complete"
       (click)="onToggleComplete($event)"
       type="checkbox"
+      [title]="(!!todo.complete
+        ? 'todoTable.row.checkboxLabel.completed.title'
+        : 'todoTable.row.checkboxLabel.unCompleted.title') | translate"
       [attr.aria-checked]="!!todo.complete"
       [attr.aria-label]="(todo.complete 
         ? 'todoTable.row.checkboxLabel.completed.title'
@@ -36,6 +44,7 @@
         (keyup.enter)="save($event)"
         (keyup.escape)="save($event)"
         name="editTodoTitle"
+        maxlength="40"
         [attr.aria-label]="'todoTable.row.title.editInput.ariaLabel' | translate">
     </ng-template>
   </div>

--- a/src/assets/i18n/FR_fr.json
+++ b/src/assets/i18n/FR_fr.json
@@ -18,11 +18,11 @@
         }
       },
       "all": {
-      "label": "Vider",
-      "title": {
-        "enabled": "Supprimer toutes les tâches",
-        "disabled": "Aucune tâche à supprimer"
-      },
+        "label": "Vider",
+        "title": {
+          "enabled": "Supprimer toutes les tâches",
+          "disabled": "Aucune tâche à supprimer"
+        },
         "messages": {
           "success": "Toutes les tâches ont été supprimées avec succès !",
           "error": "Une erreur est survenue lors de la suppression de toutes les tâches. Réessayez."
@@ -32,7 +32,14 @@
   },
   "addTodoForm": {
     "placeholder": "Nouvelle tâche...(ex: Appeler maman)",
-    "add": {
+    "input": {
+      "whitespace": {
+        "messages": {
+          "error": "Le titre ne peut pas contenir uniquement des espaces."
+        }
+      }
+    },
+    "button": {
       "title": "Ajouter",
       "messages": {
         "success": "Tâche créée avec succès !",
@@ -65,6 +72,10 @@
         }
       },
       "title": {
+        "editing": {
+          "idle": "Double-cliquez pour modifier le titre.",
+          "active": "Appuyer sur Entrée, Échap ou cliquez ailleurs (hors champs désactivé) pour enregistrer votre modification."
+        },
         "editInput": {
           "ariaLabel": "Modifier le titre",
           "messages": {


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
------------------------------------------------------
- Leading and trailing whitespace in todo titles are trimmed.
- Titles cannot be longer than 40 characters.
- Todo-text and checkbox have a descriptive title attribute for accessibility
- Implement e2e test to protect these functionalities from regression.

Does this close any currently open issues?
---------------------------------------------
Closes #15, Closes #9, Closes #8, Closes #20

Any other comments?
-----------------------
_None_.

I'm not a dummy, so I've checked these
-----------------------------------------
- [x] I've made changes requested by Copilot.
- [x] I made a **self-review**.